### PR TITLE
Line height bug on iOS

### DIFF
--- a/ios/ShardKit/Classes/TextViewImpl.swift
+++ b/ios/ShardKit/Classes/TextViewImpl.swift
@@ -14,6 +14,22 @@ internal struct SubstringTapEvent {
     var handler: () -> ()
 }
 
+internal class CustomUILabel: UILabel {
+    internal var lineHeightMultiple = Float(1)
+    
+    override func drawText(in rect: CGRect) {
+        if lineHeightMultiple != 1, let string = self.attributedText {
+            let height = string.size().height
+            
+            let offset = ((height / CGFloat(lineHeightMultiple)) - height) / 2
+            
+            super.drawText(in: rect.offsetBy(dx: 0, dy: offset))
+        } else {
+            super.drawText(in: rect)
+        }
+    }
+}
+
 internal class TextViewImpl: BaseViewImpl {
     internal var text: NSAttributedString = NSAttributedString()
     internal var numberOfLines: Int = -1
@@ -67,7 +83,7 @@ internal class TextViewImpl: BaseViewImpl {
     }
     
     override func createView() -> UIView {
-        let label = UILabel()
+        let label = CustomUILabel()
         label.textColor = .black
         label.font = systemFont
         label.isUserInteractionEnabled = true
@@ -77,22 +93,11 @@ internal class TextViewImpl: BaseViewImpl {
     override func bindView(_ view: UIView) {
         super.bindView(view)
         
-        let view = view as! UILabel
+        let view = view as! CustomUILabel
         view.attributedText = textWithLineHeight()
         view.textAlignment = self.textAlignment
         view.numberOfLines = self.numberOfLines
-        view.backgroundColor = UIColor.yellow
-        
-        let size = view.attributedText!.size()
-        let baselineOffset = size.height * CGFloat(lineHeightMultiple - 1) / 2
-        print("baselineOffset: \(baselineOffset)")
-        print("string.size(): \(size)")
-        
-        /*string.addAttribute(
-         .baselineOffset,
-         value: baselineOffset,
-         range: NSRange(location: 0, length: string.length)
-         )*/
+        view.lineHeightMultiple = self.lineHeightMultiple
     }
     
     func attributedString(from props: [String: JsonValue], attributes: [NSAttributedString.Key : Any], location: Int? = nil) throws -> NSAttributedString {

--- a/ios/ShardKit/Classes/TextViewImpl.swift
+++ b/ios/ShardKit/Classes/TextViewImpl.swift
@@ -14,7 +14,12 @@ internal struct SubstringTapEvent {
     var handler: () -> ()
 }
 
-internal class CustomUILabel: UILabel {
+// It seems like setting lineHeightMultiple (as a paragraph attribute on an
+// attributed string) isn't shifting the top of the lines, but the center. This
+// means that the text won't be vertical aligned in the UILabel. This UILabel
+// subclass will fix this problem by setting an offset on the rect in the
+// drawRect method.
+internal class LineHeightFixUILabel: UILabel {
     internal var lineHeightMultiple = Float(1)
     
     override func drawText(in rect: CGRect) {
@@ -83,7 +88,7 @@ internal class TextViewImpl: BaseViewImpl {
     }
     
     override func createView() -> UIView {
-        let label = CustomUILabel()
+        let label = LineHeightFixUILabel()
         label.textColor = .black
         label.font = systemFont
         label.isUserInteractionEnabled = true
@@ -93,7 +98,7 @@ internal class TextViewImpl: BaseViewImpl {
     override func bindView(_ view: UIView) {
         super.bindView(view)
         
-        let view = view as! CustomUILabel
+        let view = view as! LineHeightFixUILabel
         view.attributedText = textWithLineHeight()
         view.textAlignment = self.textAlignment
         view.numberOfLines = self.numberOfLines

--- a/ios/ShardKit/Classes/TextViewImpl.swift
+++ b/ios/ShardKit/Classes/TextViewImpl.swift
@@ -81,6 +81,18 @@ internal class TextViewImpl: BaseViewImpl {
         view.attributedText = textWithLineHeight()
         view.textAlignment = self.textAlignment
         view.numberOfLines = self.numberOfLines
+        view.backgroundColor = UIColor.yellow
+        
+        let size = view.attributedText!.size()
+        let baselineOffset = size.height * CGFloat(lineHeightMultiple - 1) / 2
+        print("baselineOffset: \(baselineOffset)")
+        print("string.size(): \(size)")
+        
+        /*string.addAttribute(
+         .baselineOffset,
+         value: baselineOffset,
+         range: NSRange(location: 0, length: string.length)
+         )*/
     }
     
     func attributedString(from props: [String: JsonValue], attributes: [NSAttributedString.Key : Any], location: Int? = nil) throws -> NSAttributedString {
@@ -207,7 +219,8 @@ internal class TextViewImpl: BaseViewImpl {
         string.addAttribute(
             .paragraphStyle,
             value: paragraphStyle,
-            range: NSRange(location: 0, length: string.length))
+            range: NSRange(location: 0, length: string.length)
+        )
         
         return string
     }


### PR DESCRIPTION
Seems like setting `lineHeightMultiple` (as a paragraph attribute on an attributed string) isn't shifting the top of the lines, but the center. This means that the text won't be vertical aligned in the `UILabel`. This is an attempt to fix the problem by extending `UILabel` and setting an offset on the rect in the `drawRect` method. Would be glad if we could fix this in a more elegant way though!

Before (example with line-height 200%):

<img width="352" alt="screenshot 2019-01-31 at 15 13 21" src="https://user-images.githubusercontent.com/11680517/52092011-2987ba00-256b-11e9-8926-8b4631d99693.png">

After (example with line-height 200%):

<img width="349" alt="screenshot 2019-01-31 at 15 12 32" src="https://user-images.githubusercontent.com/11680517/52092006-268cc980-256b-11e9-91ed-6f3749bace77.png">
